### PR TITLE
[#4] Correct Read The Docs integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,5 +2,13 @@
 
 version: 2
 
+python:
+   version: 3.7
+   install:
+      - requirements: sphinxdocs/requirements.txt
+      - method: setuptools
+        path: .
+   system_packages: true
+
 sphinx:
-  configuration: sphinxdocs/conf.py
+   configuration: sphinxdocs/conf.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 CHANGES
 =======
 
+1.1.3
+-----
+
+ - Correct Read The Docs integration
+
 1.1.2
 -----
 

--- a/sphinxdocs/conf.py
+++ b/sphinxdocs/conf.py
@@ -18,12 +18,15 @@ import subprocess
 import os
 from crl.examplelib._version import get_version
 
-try:
-    TOXINIDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+
+def run_robotdocs(_):
+    toxinidir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                              os.pardir)
-    subprocess.check_call(['tox', '-c', TOXINIDIR, '-e', 'robotdocs'])
-except NameError:
-    pass
+    subprocess.check_call(['tox', '-c', toxinidir, '-e', 'robotdocs'])
+
+
+def setup(app):
+    app.connect('builder-inited', run_robotdocs)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/src/crl/examplelib/_version.py
+++ b/src/crl/examplelib/_version.py
@@ -1,5 +1,5 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 GITHASH = ''
 
 


### PR DESCRIPTION
Read The Docs does not install with 'python setup.py install' the
package.  This is corrected by calling 'python setup.py install' from
conf.py. Moreover, requirements (tox) are not installed by Read The Docs
so this is now also explicitely installed in conf.py.