### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-
-
-## License
-
-This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/crl-examplelib/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/crl-examplelib/blob/master/LICENSE).

--- a/README.rst
+++ b/README.rst
@@ -26,3 +26,8 @@ Development practices
 
 The development and the testing follows the Common Robot Libraries development
 practices defined in https://github.com/nokia/crl-devutils.
+
+License
+-------
+
+This project is licensed under the BSD-3-Clause license - see the `LICENSE <https://github.com/nokia/crl-examplelib/blob/master/LICENSE>`_.


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.